### PR TITLE
Hide hero section when viewing a module

### DIFF
--- a/app.js
+++ b/app.js
@@ -203,9 +203,12 @@
 
     if (card) card.classList.add(VT_SOURCE_CLASS);
 
+    const siteHeader = document.querySelector('.site-header');
+
     const swap = () => {
       grid.hidden = true;
       if (sectionHead) sectionHead.hidden = true;
+      if (siteHeader) siteHeader.hidden = true;
       renderPanel(moduleId);
       window.scrollTo(0, 0);
     };
@@ -233,11 +236,14 @@
     const grid = document.querySelector('.module-grid');
     const sectionHead = document.querySelector('.grid-scene .modules-section-head');
 
+    const siteHeader = document.querySelector('.site-header');
+
     const swap = () => {
       panelContainer.innerHTML = '';
       state.activeModule = null;
       grid.hidden = false;
       if (sectionHead) sectionHead.hidden = false;
+      if (siteHeader) siteHeader.hidden = false;
       const card = document.querySelector(`.module-card[data-module="${moduleId}"]`);
       if (card) card.classList.add(VT_SOURCE_CLASS);
     };
@@ -264,11 +270,14 @@
     const moduleGrid = document.querySelector('.module-grid');
     const moduleSectionHead = document.querySelector('.grid-scene .modules-section-head');
 
+    const siteHeader = document.querySelector('.site-header');
+
     /* Any open module panel is closed when view changes. */
     panelContainer.innerHTML = '';
     state.activeModule = null;
     if (moduleGrid) moduleGrid.hidden = false;
     if (moduleSectionHead) moduleSectionHead.hidden = false;
+    if (siteHeader) siteHeader.hidden = false;
 
     if (view === 'all') {
       gridScene.hidden = true;


### PR DESCRIPTION
## Summary

- Hides the `.site-header` (hero section with eyebrow quote, h1, and lede) when a user opens a module
- Restores the header when the user navigates back to the module grid via "← All Modules" or switches between Modules/All Verses views

## How it works

Three small additions to `app.js`:
- `openModule()` — sets `siteHeader.hidden = true` inside the swap callback (runs within the View Transition)
- `closeModule()` — sets `siteHeader.hidden = false` inside the swap callback
- `applyView()` — sets `siteHeader.hidden = false` to cover the case where the user switches views while a module is open

## Test plan

- [x] Open any module — hero (quote, title, lede) should disappear; only module number, module title, and verses visible at top
- [x] Click "← All Modules" — hero should reappear
- [x] Open a module, then click "All Verses" toggle — hero should reappear
- [x] Verify no visual regression on the main modules grid or All Verses view

https://claude.ai/code/session_01Wx4HfBDJWHNqajS7L8hM2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx4HfBDJWHNqajS7L8hM2L)_