### PR TITLE
Make selector bar sticky and keep toggles inline

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,24 +117,22 @@
       class: 'panel',
       style: { '--accent': mod.color }
     }, [
-      el('div', { class: 'panel-header' }, [
-        el('div', {}, [
-          el('div', { class: 'panel-eyebrow', style: { color: mod.color } },
-            `Module ${String(mod.id).padStart(2, '0')}`),
-          el('h2', { class: 'panel-title' }, mod.name)
-        ]),
-        el('div', { class: 'panel-controls' }, [
-          el('div', { class: 'translation-toggle', role: 'group', 'aria-label': 'Bible translation' }, [
-            el('button', { type: 'button', dataset: { tr: 'NIV' } }, 'NIV'),
-            el('div', { class: 'divider' }),
-            el('button', { type: 'button', dataset: { tr: 'ESV' } }, 'ESV')
-          ]),
-          el('button', {
-            class: 'back-link',
-            type: 'button',
-            onclick: closeModule
-          }, '← All Modules')
+      el('div', { class: 'panel-toolbar' }, [
+        el('button', {
+          class: 'back-link',
+          type: 'button',
+          onclick: closeModule
+        }, '← All Modules'),
+        el('div', { class: 'translation-toggle', role: 'group', 'aria-label': 'Bible translation' }, [
+          el('button', { type: 'button', dataset: { tr: 'NIV' } }, 'NIV'),
+          el('div', { class: 'divider' }),
+          el('button', { type: 'button', dataset: { tr: 'ESV' } }, 'ESV')
         ])
+      ]),
+      el('div', { class: 'panel-header' }, [
+        el('div', { class: 'panel-eyebrow', style: { color: mod.color } },
+          `Module ${String(mod.id).padStart(2, '0')}`),
+        el('h2', { class: 'panel-title' }, mod.name)
       ]),
       el('div', { class: 'verse-grid' },
         mod.verses.map(v => renderVerseCard(v))

--- a/styles.css
+++ b/styles.css
@@ -224,11 +224,19 @@ main {
 }
 
 /* ===== PANEL ===== */
-.panel-header {
+.panel-toolbar {
   display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: var(--md);
+  align-items: center;
+  gap: var(--xs);
+  flex-wrap: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--canvas);
+  padding: var(--xs) 0;
+  margin-bottom: var(--md);
+}
+.panel-header {
   margin-bottom: var(--md);
   padding-bottom: var(--sm);
   border-bottom: 1px solid var(--hairline);
@@ -256,23 +264,14 @@ main {
   text-transform: uppercase;
   color: var(--ink);
   cursor: pointer;
-  padding: var(--xs) var(--sm);
+  padding: 14px var(--sm);
   border: 1px solid var(--ink);
   background: transparent;
   white-space: nowrap;
-  height: 48px;
   user-select: none;
   transition: background 0.15s var(--ease-out), color 0.15s var(--ease-out);
 }
 .back-link:hover { background: var(--ink); color: var(--canvas); }
-
-.panel-controls {
-  display: flex;
-  align-items: stretch;
-  gap: var(--xs);
-  flex-wrap: wrap;
-}
-.panel-controls .translation-toggle { height: 48px; }
 
 /* ===== VERSE CARDS ===== */
 .verse-grid {
@@ -417,15 +416,20 @@ footer {
   .site-header { padding: var(--lg) var(--sm) var(--md); }
   .site-header h1 { font-size: 34px; letter-spacing: -0.68px; }
   main { padding: var(--lg) var(--sm) var(--xl); }
-  .panel-header { flex-direction: column; align-items: flex-start; gap: var(--sm); }
   .panel-title { font-size: 28px; }
-  .modules-section-head {
+  .modules-section-head,
+  .panel-toolbar {
     gap: var(--xs);
     padding: var(--xxs) 0;
     margin-bottom: var(--md);
   }
   .translation-toggle button,
   .view-toggle button {
+    padding: 10px 14px;
+    font-size: 12px;
+    letter-spacing: 0.8px;
+  }
+  .back-link {
     padding: 10px 14px;
     font-size: 12px;
     letter-spacing: 0.8px;
@@ -437,6 +441,11 @@ footer {
   .verse-grid  { grid-template-columns: 1fr; }
   .translation-toggle button,
   .view-toggle button {
+    padding: 8px 10px;
+    font-size: 11px;
+    letter-spacing: 0.4px;
+  }
+  .back-link {
     padding: 8px 10px;
     font-size: 11px;
     letter-spacing: 0.4px;

--- a/styles.css
+++ b/styles.css
@@ -64,9 +64,9 @@ button {
 /* ===== SEGMENTED TOGGLES (translation + view) ===== */
 .header-controls {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: var(--xs);
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 .translation-toggle,
 .view-toggle {
@@ -120,11 +120,14 @@ main {
 }
 .modules-section-head {
   display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
+  align-items: center;
   gap: var(--md);
   margin-bottom: var(--lg);
-  flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--canvas);
+  padding: var(--xs) 0;
 }
 /* ===== SCENES ===== */
 .grid-scene[hidden],
@@ -416,12 +419,28 @@ footer {
   main { padding: var(--lg) var(--sm) var(--xl); }
   .panel-header { flex-direction: column; align-items: flex-start; gap: var(--sm); }
   .panel-title { font-size: 28px; }
-  .modules-section-head { flex-direction: column; align-items: flex-start; }
+  .modules-section-head {
+    gap: var(--xs);
+    padding: var(--xxs) 0;
+    margin-bottom: var(--md);
+  }
+  .translation-toggle button,
+  .view-toggle button {
+    padding: 10px 14px;
+    font-size: 12px;
+    letter-spacing: 0.8px;
+  }
   footer { padding: var(--md) var(--sm); }
 }
 @media (max-width: 420px) {
   .module-grid { grid-template-columns: 1fr 1fr; gap: var(--xxs); }
   .verse-grid  { grid-template-columns: 1fr; }
+  .translation-toggle button,
+  .view-toggle button {
+    padding: 8px 10px;
+    font-size: 11px;
+    letter-spacing: 0.4px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Keeps view + translation toggles on one row at every viewport (was
wrapping/stacking under 720px), sticks the bar to the top of the page
so it stays visible while scrolling, and shrinks the buttons on mobile
so the sticky bar stays compact.