### PR TITLE
Fix iMessage link preview image

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,20 +10,24 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://clc-verses.netlify.app/">
 <meta property="og:title" content="CLC Verses">
-<meta property="og:image" content="https://raw.githubusercontent.com/sieis/clc-verses/8b520c6972a727e28d7e8974b9704c9c4883464c/assets/twitterimg.png">
+<meta property="og:image" content="https://clc-verses.netlify.app/assets/twitterimg.png">
+<meta property="og:image:secure_url" content="https://clc-verses.netlify.app/assets/twitterimg.png">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="2006">
+<meta property="og:image:height" content="892">
+<meta property="og:image:alt" content="CLC Verses — All-In Scripture Memorization">
 <meta property="og:description" content="Reference for all memory verses in CLC 2 Year All-In Curriculum">
 <meta property="og:site_name" content="CLC Verses">
 <meta property="og:locale" content="en_US">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
 
 <!-- Twitter Card -->
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:creator" content="@eamonncottrell">
 <meta name="twitter:url" content="https://clc-verses.netlify.app/">
 <meta name="twitter:title" content="CLC Verses">
 <meta name="twitter:description" content="Reference for all memory verses in CLC 2 Year All-In Curriculum">
-<meta name="twitter:image" content="https://raw.githubusercontent.com/sieis/clc-verses/8b520c6972a727e28d7e8974b9704c9c4883464c/assets/twitterimg.png">
+<meta name="twitter:image" content="https://clc-verses.netlify.app/assets/twitterimg.png">
+<meta name="twitter:image:alt" content="CLC Verses — All-In Scripture Memorization">
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
- Correct og:image:width/height to actual image dimensions (2006x892)
- Switch twitter:card to summary_large_image for wide preview image
- Serve og:image from canonical site origin instead of a pinned
  raw.githubusercontent.com SHA so the preview survives repo changes
- Add og:image:type, og:image:secure_url, and image alt text