### PR TITLE
Add prev/next module navigation inside module panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,6 +110,9 @@
 
   function renderPanel(moduleId) {
     const mod = data.modules.find(m => m.id === moduleId);
+    const idx = data.modules.findIndex(m => m.id === moduleId);
+    const prevMod = idx > 0 ? data.modules[idx - 1] : null;
+    const nextMod = idx >= 0 && idx < data.modules.length - 1 ? data.modules[idx + 1] : null;
     const container = document.querySelector('.panel-container');
     container.innerHTML = '';
 
@@ -118,11 +121,27 @@
       style: { '--accent': mod.color }
     }, [
       el('div', { class: 'panel-toolbar' }, [
-        el('button', {
-          class: 'back-link',
-          type: 'button',
-          onclick: closeModule
-        }, '← All Modules'),
+        el('div', { class: 'panel-nav' }, [
+          el('button', {
+            class: 'nav-link nav-prev',
+            type: 'button',
+            'aria-label': prevMod ? `Previous module: ${prevMod.name}` : 'No previous module',
+            disabled: prevMod ? null : '',
+            onclick: prevMod ? () => goToModule(prevMod.id) : null
+          }, '←'),
+          el('button', {
+            class: 'back-link',
+            type: 'button',
+            onclick: closeModule
+          }, 'All Modules'),
+          el('button', {
+            class: 'nav-link nav-next',
+            type: 'button',
+            'aria-label': nextMod ? `Next module: ${nextMod.name}` : 'No next module',
+            disabled: nextMod ? null : '',
+            onclick: nextMod ? () => goToModule(nextMod.id) : null
+          }, '→')
+        ]),
         el('div', { class: 'translation-toggle', role: 'group', 'aria-label': 'Bible translation' }, [
           el('button', { type: 'button', dataset: { tr: 'NIV' } }, 'NIV'),
           el('div', { class: 'divider' }),
@@ -221,6 +240,30 @@
 
     done.finally(() => {
       if (card) card.classList.remove(VT_SOURCE_CLASS);
+      state.isAnimating = false;
+    });
+  }
+
+  function goToModule(moduleId) {
+    if (state.isAnimating) return;
+    if (moduleId === state.activeModule) return;
+    state.isAnimating = true;
+    state.activeModule = moduleId;
+
+    const swap = () => {
+      renderPanel(moduleId);
+      window.scrollTo(0, 0);
+    };
+
+    let done;
+    if (VT_SUPPORTED) {
+      done = document.startViewTransition(swap).finished.catch(() => {});
+    } else {
+      swap();
+      done = Promise.resolve();
+    }
+
+    done.finally(() => {
       state.isAnimating = false;
     });
   }

--- a/styles.css
+++ b/styles.css
@@ -273,6 +273,34 @@ main {
 }
 .back-link:hover { background: var(--ink); color: var(--canvas); }
 
+.panel-nav {
+  display: inline-flex;
+  align-items: stretch;
+  gap: var(--xxs);
+}
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--ink);
+  cursor: pointer;
+  padding: 14px var(--xs);
+  min-width: 48px;
+  border: 1px solid var(--ink);
+  background: transparent;
+  white-space: nowrap;
+  user-select: none;
+  transition: background 0.15s var(--ease-out), color 0.15s var(--ease-out), opacity 0.15s var(--ease-out);
+}
+.nav-link:hover:not(:disabled) { background: var(--ink); color: var(--canvas); }
+.nav-link:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
 /* ===== VERSE CARDS ===== */
 .verse-grid {
   display: grid;
@@ -434,6 +462,11 @@ footer {
     font-size: 12px;
     letter-spacing: 0.8px;
   }
+  .nav-link {
+    padding: 10px 10px;
+    min-width: 40px;
+    font-size: 14px;
+  }
   footer { padding: var(--md) var(--sm); }
 }
 @media (max-width: 420px) {
@@ -449,6 +482,11 @@ footer {
     padding: 8px 10px;
     font-size: 11px;
     letter-spacing: 0.4px;
+  }
+  .nav-link {
+    padding: 8px 8px;
+    min-width: 34px;
+    font-size: 13px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Flank the **All Modules** button in the panel toolbar with **←** and **→** arrow buttons that jump straight to the previous or next module's verses, so you no longer need to pop out to the grid to switch modules.
- Buttons disable (dimmed, non-interactive) on the first/last module so the boundaries are obvious.
- Navigation reuses the existing View Transitions API path, so module-to-module swaps animate consistently with the rest of the app.

## Test plan
- [ ] Open Module 01 — the **←** button should be disabled; **→** should advance to Module 02.
- [ ] Click **→** repeatedly through to Module 12; the **→** button should disable on the last module.
- [ ] Click **←** to step backward through modules.
- [ ] **All Modules** still returns to the grid.
- [ ] Translation toggle (NIV/ESV) still works after navigating between modules.
- [ ] Verify layout on mobile widths (≤720px and ≤420px) — toolbar should still fit on one row.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdNXz8QdJiUvQHJhBECHvg)_